### PR TITLE
Version that doesn't require a database

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ back-end API), you will need to set the following paramaters in your app's setti
     MIGRATION_MODULES = {'govuk_template_base': None}  # don't try to run migrations on this app
     SERVICE_SETTINGS = {
         'localised_name': 'My New Service',
-        'phase': 'alpha',  # 
+        'phase': 'alpha',  # Only required to remove the banner for 'live' phase
         'phase_name': 'Alpha',
         'has_header_links': True,
         'header_link_url': 'http://www.myurl.gov.uk/',

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ Usage
 
 - Setup a Django project using ``manage.py startproject`` or other means
 - Install ``django-govuk-template`` and add ``govuk_template_base`` to ``INSTALLED_APPS``
+- Install ``libsass`` with ``pip install libsass``. This helps to build the downloaded govuk_template system.
 - Call ``manage.py startgovukapp [[app name, e.g. govuk_template]]``
     - Add this app to ``INSTALLED_APPS``
     - Ensure that this app is included in source control as the intention is that it’s only rebuilt as needed

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,41 @@ See the demo folder in this repository on `GitHub`_, it is not included in distr
 Additionally, add ``django-govuk-forms`` to your project to output Django forms styled using GOV.UK elements.
 You can install this package automatically by adding ``django-govuk-template[forms]`` to your requirements file.
 
+No-database mode
+----------------
+
+If you want to use this package in a Django app that doesn't have a database (eg a front-end app consuming a
+back-end API), you will need to set the following paramaters in your app's settings file:
+
+.. code:: python
+
+    GOVUK_TEMPLATE_NO_DATABASE = True
+    MIGRATION_MODULES = {'govuk_template_base': None}  # don't try to run migrations on this app
+    SERVICE_SETTINGS = {
+        'localised_name': 'My New Service',
+        'phase': 'alpha',  # 
+        'phase_name': 'Alpha',
+        'has_header_links': True,
+        'header_link_url': 'http://www.myurl.gov.uk/',
+        'header_links': {
+            'all': [
+                {
+                    'url': 'https://www.myurl.gov.uk/header1',
+                    'localised_name': 'Header link 1'
+                }
+            ]
+        }
+        'has_footer_links': True,
+        'footer_links': {
+            'all': [
+                {
+                    'url': 'https://www.myurl.gov.uk/footer1',
+                    'localised_name': 'Footer link 1'
+                }
+            ]
+        }
+    }
+
 Development
 -----------
 

--- a/govuk_template_base/models.py
+++ b/govuk_template_base/models.py
@@ -5,6 +5,7 @@ from django.core.validators import URLValidator
 from django.db import models
 from django.urls import NoReverseMatch, reverse
 from django.utils.translation import gettext, gettext_lazy as _, pgettext_lazy
+from django.conf import settings
 
 
 class ServicePhase(enum.Enum):
@@ -39,13 +40,18 @@ class ServiceSettings(models.Model):
     class Meta:
         ordering = ('-modified',)
         verbose_name = verbose_name_plural = _('Service settings')
+        if hasattr(settings, 'GOVUK_TEMPLATE_NO_DATABASE') and settings.GOVUK_TEMPLATE_NO_DATABASE:
+            managed = False
 
     def __str__(self):
         return self.name
 
     @classmethod
     def default_settings(cls):
-        return cls.objects.first() or cls.objects.create(name='Untitled')
+        if hasattr(settings, 'GOVUK_TEMPLATE_NO_DATABASE') and settings.GOVUK_TEMPLATE_NO_DATABASE:
+            return settings.SERVICE_SETTINGS
+        else:
+            return cls.objects.first() or cls.objects.create(name='Untitled')
 
     @property
     def localised_name(self):

--- a/tests/test_nodatabase.py
+++ b/tests/test_nodatabase.py
@@ -1,0 +1,47 @@
+import unittest
+import django
+
+
+class NoDatabaseTestCase(unittest.TestCase):
+    def setUp(self):
+        from django.conf import settings
+        settings.configure(
+            DEBUG=True,
+            LOGGING_CONFIG=None,
+            GOVUK_TEMPLATE_NO_DATABASE=True,
+            MIGRATION_MODULES={'govuk_template_base': None},
+            SERVICE_SETTINGS={
+                'localised_name': 'Test Service',
+                'phase': 'beta',
+                'phase_name': 'Beta',
+                'has_header_links': True,
+                'header_link_url': 'http://www.testservice.gov.uk/',
+                'header_links': {
+                    'all': [
+                        {
+                            'url': 'https://www.testservice.gov.uk/header1',
+                            'localised_name': 'Header link 1'
+                        }
+                    ]
+                },
+                'has_footer_links': True,
+                'footer_links': {
+                    'all': [
+                        {
+                            'url': 'https://www.testservice.gov.uk/footer1',
+                            'localised_name': 'Footer link 1'
+                        }
+                    ]
+                }
+            },
+            INSTALLED_APPS=('govuk_template_base',)
+        )
+        django.setup()
+
+    def test_no_database(self):
+        from govuk_template_base.templatetags import govuk_template_base
+        service_settings = govuk_template_base.get_service_settings()
+        self.assertEqual(service_settings['localised_name'], 'Test Service')
+        self.assertEqual(service_settings['phase'], 'beta')
+        self.assertEqual(service_settings['phase_name'], 'Beta')
+        self.assertEqual(service_settings['has_header_links'], True)


### PR DESCRIPTION
Suggested change allowing for the use of django-govuk-template with no database. Service Settings are included in the app's `SETTINGS` rather than in a database table.

We have some front-end apps in which we don't want to run a database so this allows us to use django-govuk-template on those apps.